### PR TITLE
keep issued gov token in dao sc

### DIFF
--- a/entity/src/governance/mod.rs
+++ b/entity/src/governance/mod.rs
@@ -416,7 +416,6 @@ pub trait GovernanceModule:
         match result {
             ManagedAsyncCallResult::Ok(_) => {
                 let payment = self.call_value().single_esdt();
-                self.send().direct_esdt(&initial_caller, &payment.token_identifier, 0, &payment.amount);
                 self.configure_governance_token(payment.token_identifier, payment.amount, true);
             }
             ManagedAsyncCallResult::Err(_) => self.send_received_egld(&initial_caller),


### PR DESCRIPTION
It was sent to the creator on time of implementation because there was no easy transfer mechanism in place.

Now, transfers can be easily initiated via proposals.