### PR TITLE
add direct execute endpoint

### DIFF
--- a/entity/src/governance/events.rs
+++ b/entity/src/governance/events.rs
@@ -27,6 +27,10 @@ pub trait GovEventsModule {
         self.execute_event(self.blockchain().get_caller(), proposal.id);
     }
 
+    fn emit_direct_execute_event(&self) {
+        self.direct_execute_event(self.blockchain().get_caller());
+    }
+
     fn emit_withdraw_event(&self, proposal: &Proposal<Self::Api>) {
         self.withdraw_event(self.blockchain().get_caller(), proposal.id);
     }
@@ -45,6 +49,9 @@ pub trait GovEventsModule {
 
     #[event("execute")]
     fn execute_event(&self, #[indexed] caller: ManagedAddress, #[indexed] proposal: u64);
+
+    #[event("direct_execute")]
+    fn direct_execute_event(&self, #[indexed] caller: ManagedAddress);
 
     #[event("withdraw")]
     fn withdraw_event(&self, #[indexed] caller: ManagedAddress, #[indexed] proposal: u64);

--- a/entity/src/governance/mod.rs
+++ b/entity/src/governance/mod.rs
@@ -339,6 +339,7 @@ pub trait GovernanceModule:
         let actions_hash = self.calculate_actions_hash(&actions);
         let mut proposal = self.proposals(proposal_id).get();
         require!(proposal.actions_hash == actions_hash, "actions have been corrupted");
+        require!(!proposal.was_executed, "proposal has already been executed");
 
         let has_approval = self.get_proposal_status(&proposal) == ProposalStatus::Succeeded;
         let (allowed, permissions) = self.get_user_permissions_for_actions(&proposal.proposer, &actions, has_approval);

--- a/entity/src/governance/proposal.rs
+++ b/entity/src/governance/proposal.rs
@@ -319,35 +319,16 @@ pub trait ProposalModule: config::ConfigModule + permission::PermissionModule + 
     }
 
     fn can_propose(&self, proposer: &ManagedAddress, actions_hash: &ManagedBuffer, permissions: &ManagedVec<ManagedBuffer>) -> (bool, ManagedVec<Policy<Self::Api>>) {
-        let proposer_id = self.users().get_user_id(proposer);
-        let proposer_roles = self.user_roles(proposer_id);
-        let mut policies = ManagedVec::new();
-
         // no actions -> always allowed
         if actions_hash.is_empty() && permissions.is_empty() {
-            return (true, policies);
+            return (true, ManagedVec::new());
         }
 
         if self.is_leaderless() {
-            return (true, policies);
+            return (true, ManagedVec::new());
         }
 
-        let mut allowed = false;
-
-        for role in proposer_roles.iter() {
-            if role == ManagedBuffer::from(ROLE_BUILTIN_LEADER) {
-                allowed = true;
-            }
-
-            for permission in permissions.into_iter() {
-                if let Some(policy) = self.policies(&role).get(&permission) {
-                    policies.push(policy);
-                    allowed = true;
-                }
-            }
-        }
-
-        (allowed, policies)
+        self.get_user_policies_for_permissions(proposer, permissions)
     }
 
     fn calculate_actions_hash(&self, actions: &ManagedVec<Action<Self::Api>>) -> ManagedBuffer<Self::Api> {
@@ -368,10 +349,11 @@ pub trait ProposalModule: config::ConfigModule + permission::PermissionModule + 
         self.crypto().keccak256(&serialized).as_managed_buffer().clone()
     }
 
-    fn get_actual_permissions(&self, proposal: &Proposal<Self::Api>, actions: &ManagedVec<Action<Self::Api>>) -> ManagedVec<ManagedBuffer> {
-        let proposer_id = self.users().get_user_id(&proposal.proposer);
+    fn get_user_permissions_for_actions(&self, address: &ManagedAddress, actions: &ManagedVec<Action<Self::Api>>) -> (bool, ManagedVec<ManagedBuffer>) {
+        let proposer_id = self.users().get_user_id(&address);
         let proposer_roles = self.user_roles(proposer_id);
         let mut actual_permissions = ManagedVec::new();
+        let mut allowed = true;
 
         for action in actions.into_iter() {
             let mut has_permission_for_action = false;
@@ -390,16 +372,18 @@ pub trait ProposalModule: config::ConfigModule + permission::PermissionModule + 
                     }
                 }
 
-                // leader does not need permission for all actions defined
+                // leader does not need permission for actions
                 if role == ManagedBuffer::from(ROLE_BUILTIN_LEADER) {
                     has_permission_for_action = true;
                 }
             }
 
-            require!(has_permission_for_action, "no permission for action");
+            if !has_permission_for_action {
+                allowed = false;
+            }
         }
 
-        actual_permissions
+        (allowed, actual_permissions)
     }
 
     fn does_permission_apply_to_action(&self, permission_details: &PermissionDetails<Self::Api>, action: &Action<Self::Api>) -> bool {

--- a/entity/tests/direct_execute_tests.rs
+++ b/entity/tests/direct_execute_tests.rs
@@ -1,0 +1,119 @@
+use entity::config::*;
+use entity::governance::proposal::*;
+use entity::governance::*;
+use entity::permission::*;
+use multiversx_sc::types::*;
+use multiversx_sc_scenario::*;
+use setup::*;
+
+mod setup;
+
+#[test]
+fn it_direct_executes_an_action() {
+    let mut setup = EntitySetup::new(entity::contract_obj);
+    let proposer_address = setup.user_address.clone();
+    let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
+
+    setup.configure_gov_token(true);
+
+    setup.blockchain.set_egld_balance(setup.contract.address_ref(), &rust_biguint!(1));
+
+    setup
+        .blockchain
+        .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
+            sc.create_role(managed_buffer!(b"developer"));
+            sc.assign_role(managed_address!(&proposer_address), managed_buffer!(b"developer"));
+            sc.create_permission(
+                managed_buffer!(b"sendEgld"),
+                managed_biguint!(1),
+                managed_address!(&action_receiver),
+                ManagedBuffer::new(),
+                ManagedVec::new(),
+                ManagedVec::new(),
+            );
+            sc.create_policy(
+                managed_buffer!(b"developer"),
+                managed_buffer!(b"sendEgld"),
+                PolicyMethod::One,
+                BigUint::from(1u64),
+                10,
+            );
+        })
+        .assert_ok();
+
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
+
+    setup
+        .blockchain
+        .execute_tx(&proposer_address, &setup.contract, &rust_biguint!(0), |sc| {
+            let mut actions = Vec::<Action<DebugApi>>::new();
+            actions.push(Action::<DebugApi> {
+                destination: managed_address!(&action_receiver),
+                endpoint: ManagedBuffer::new(),
+                arguments: ManagedVec::new(),
+                gas_limit: 5_000_000u64,
+                value: managed_biguint!(1),
+                payments: ManagedVec::new(),
+            });
+
+            sc.direct_execute_endpoint(MultiValueManagedVec::from(actions));
+        })
+        .assert_ok();
+
+    setup.blockchain.check_egld_balance(&action_receiver, &rust_biguint!(1));
+}
+
+#[test]
+fn it_fails_when_caller_has_no_permissions() {
+    let mut setup = EntitySetup::new(entity::contract_obj);
+    let proposer_address = setup.user_address.clone();
+    let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
+
+    setup.configure_gov_token(true);
+
+    setup.blockchain.set_egld_balance(setup.contract.address_ref(), &rust_biguint!(1));
+
+    // caller is not assigned to the developer role
+    setup
+        .blockchain
+        .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
+            sc.create_role(managed_buffer!(b"developer"));
+            sc.create_permission(
+                managed_buffer!(b"sendEgld"),
+                managed_biguint!(1),
+                managed_address!(&action_receiver),
+                ManagedBuffer::new(),
+                ManagedVec::new(),
+                ManagedVec::new(),
+            );
+            sc.create_policy(
+                managed_buffer!(b"developer"),
+                managed_buffer!(b"sendEgld"),
+                PolicyMethod::One,
+                BigUint::from(1u64),
+                10,
+            );
+        })
+        .assert_ok();
+
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
+
+    setup
+        .blockchain
+        .execute_tx(&proposer_address, &setup.contract, &rust_biguint!(0), |sc| {
+            let mut actions = Vec::<Action<DebugApi>>::new();
+            actions.push(Action::<DebugApi> {
+                destination: managed_address!(&action_receiver),
+                endpoint: ManagedBuffer::new(),
+                arguments: ManagedVec::new(),
+                gas_limit: 5_000_000u64,
+                value: managed_biguint!(1),
+                payments: ManagedVec::new(),
+            });
+
+            sc.direct_execute_endpoint(MultiValueManagedVec::from(actions));
+        })
+        .assert_user_error("no permission for action");
+
+    setup.blockchain.check_egld_balance(&action_receiver, &rust_biguint!(0));
+}

--- a/entity/tests/execute_tests.rs
+++ b/entity/tests/execute_tests.rs
@@ -11,6 +11,96 @@ use setup::*;
 mod setup;
 
 #[test]
+fn it_executes_actions_of_a_proposal() {
+    let mut setup = EntitySetup::new(entity::contract_obj);
+    let proposer_address = setup.user_address.clone();
+    let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
+
+    setup.configure_gov_token(true);
+
+    setup.blockchain.set_egld_balance(setup.contract.address_ref(), &rust_biguint!(1000));
+
+    setup
+        .blockchain
+        .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
+            sc.assign_role(managed_address!(&proposer_address), managed_buffer!(ROLE_BUILTIN_LEADER));
+            sc.create_permission(
+                managed_buffer!(b"perm"),
+                managed_biguint!(5),
+                managed_address!(&action_receiver),
+                managed_buffer!(b"myendpoint"),
+                ManagedVec::new(),
+                ManagedVec::new(),
+            );
+            sc.create_policy(
+                managed_buffer!(ROLE_BUILTIN_LEADER),
+                managed_buffer!(b"perm"),
+                PolicyMethod::Quorum,
+                BigUint::from(1u64),
+                10,
+            );
+        })
+        .assert_ok();
+
+    setup
+        .blockchain
+        .execute_esdt_transfer(
+            &proposer_address,
+            &setup.contract,
+            ENTITY_GOV_TOKEN_ID,
+            0,
+            &rust_biguint!(ENTITY_GOV_TOKEN_SUPPLY),
+            |sc| {
+                let mut actions = Vec::<Action<DebugApi>>::new();
+
+                actions.push(Action::<DebugApi> {
+                    destination: managed_address!(&action_receiver),
+                    endpoint: managed_buffer!(b"myendpoint"),
+                    arguments: ManagedVec::new(),
+                    gas_limit: 5_000_000u64,
+                    value: managed_biguint!(5),
+                    payments: ManagedVec::new(),
+                });
+
+                let actions_hash = sc.calculate_actions_hash(&ManagedVec::from(actions));
+                let actions_permissions = MultiValueManagedVec::from(vec![managed_buffer!(b"perm")]);
+
+                sc.propose_endpoint(
+                    managed_buffer!(b"id"),
+                    managed_buffer!(b"a"),
+                    managed_buffer!(b"b"),
+                    actions_hash,
+                    POLL_DEFAULT_ID,
+                    actions_permissions,
+                );
+            },
+        )
+        .assert_ok();
+
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
+
+    setup
+        .blockchain
+        .execute_tx(&proposer_address, &setup.contract, &rust_biguint!(0), |sc| {
+            let mut actions = Vec::<Action<DebugApi>>::new();
+
+            actions.push(Action::<DebugApi> {
+                destination: managed_address!(&action_receiver),
+                endpoint: managed_buffer!(b"myendpoint"),
+                arguments: ManagedVec::new(),
+                gas_limit: 5_000_000u64,
+                value: managed_biguint!(5),
+                payments: ManagedVec::new(),
+            });
+
+            sc.execute_endpoint(1, MultiValueManagedVec::from(actions));
+        })
+        .assert_ok();
+
+    setup.blockchain.check_egld_balance(&action_receiver, &rust_biguint!(5));
+}
+
+#[test]
 fn it_marks_a_proposal_as_executed() {
     let mut setup = EntitySetup::new(entity::contract_obj);
     let proposer_address = setup.user_address.clone();
@@ -91,9 +181,8 @@ fn it_marks_a_proposal_as_executed() {
 }
 
 #[test]
-fn it_fails_if_attempted_to_execute_again() {
+fn it_fails_when_attempted_to_execute_again() {
     let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
     let mut proposal_id = 0;
@@ -149,7 +238,7 @@ fn it_fails_if_attempted_to_execute_again() {
         })
         .assert_ok();
 
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
 
     setup
         .blockchain
@@ -176,14 +265,14 @@ fn it_fails_if_attempted_to_execute_again() {
                 payments: ManagedVec::new(),
             });
 
-            sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
             // and again
+            sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
         })
-        .assert_user_error("no permission for action");
+        .assert_user_error("proposal has already been executed");
 }
 
 #[test]
-fn it_fails_if_the_proposal_is_still_active() {
+fn it_fails_when_the_proposal_is_still_active() {
     let mut setup = EntitySetup::new(entity::contract_obj);
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
@@ -194,22 +283,7 @@ fn it_fails_if_the_proposal_is_still_active() {
     setup
         .blockchain
         .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
-            sc.assign_role(managed_address!(&proposer_address), managed_buffer!(ROLE_BUILTIN_LEADER));
-            sc.create_permission(
-                managed_buffer!(b"perm"),
-                managed_biguint!(0),
-                managed_address!(&action_receiver),
-                managed_buffer!(b"myendpoint"),
-                ManagedVec::new(),
-                ManagedVec::new(),
-            );
-            sc.create_policy(
-                managed_buffer!(ROLE_BUILTIN_LEADER),
-                managed_buffer!(b"perm"),
-                PolicyMethod::Quorum,
-                BigUint::from(1u64),
-                10,
-            );
+            sc.remove_role(managed_buffer!(ROLE_BUILTIN_LEADER));
         })
         .assert_ok();
 
@@ -255,7 +329,60 @@ fn it_fails_if_the_proposal_is_still_active() {
             });
 
             sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
+        })
+        .assert_user_error("no permission for action");
+}
 
+#[test]
+fn it_fails_when_the_proposal_has_been_defeated() {
+    let mut setup = EntitySetup::new(entity::contract_obj);
+    let proposer_address = setup.user_address.clone();
+    let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
+    let mut proposal_id = 0;
+
+    setup.configure_gov_token(true);
+
+    setup
+        .blockchain
+        .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
+            sc.remove_role(managed_buffer!(ROLE_BUILTIN_LEADER));
+        })
+        .assert_ok();
+
+    // proposing with minimum to propose which is less than required quorum
+    setup
+        .blockchain
+        .execute_esdt_transfer(&proposer_address, &setup.contract, ENTITY_GOV_TOKEN_ID, 0, &rust_biguint!(MIN_PROPOSE_WEIGHT), |sc| {
+            let mut actions = Vec::<Action<DebugApi>>::new();
+
+            actions.push(Action::<DebugApi> {
+                destination: managed_address!(&action_receiver),
+                endpoint: managed_buffer!(b"myendpoint"),
+                arguments: ManagedVec::new(),
+                gas_limit: 5_000_000u64,
+                value: managed_biguint!(0),
+                payments: ManagedVec::new(),
+            });
+
+            let actions_hash = sc.calculate_actions_hash(&ManagedVec::from(actions));
+            let actions_permissions = MultiValueManagedVec::from(vec![managed_buffer!(b"perm")]);
+
+            proposal_id = sc.propose_endpoint(
+                managed_buffer!(b"id"),
+                ManagedBuffer::new(),
+                ManagedBuffer::new(),
+                actions_hash,
+                POLL_DEFAULT_ID,
+                actions_permissions,
+            );
+        })
+        .assert_ok();
+
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
+
+    setup
+        .blockchain
+        .execute_tx(&proposer_address, &setup.contract, &rust_biguint!(0), |sc| {
             let mut actions = Vec::<Action<DebugApi>>::new();
             actions.push(Action::<DebugApi> {
                 destination: managed_address!(&action_receiver),
@@ -267,106 +394,13 @@ fn it_fails_if_the_proposal_is_still_active() {
             });
 
             sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
-            // and again
         })
         .assert_user_error("no permission for action");
 }
 
 #[test]
-fn it_executes_actions_of_a_proposal() {
+fn it_fails_when_actions_to_execute_are_incongruent_to_actions_proposed() {
     let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
-    let proposer_address = setup.user_address.clone();
-    let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
-
-    setup.configure_gov_token(true);
-
-    setup.blockchain.set_egld_balance(setup.contract.address_ref(), &rust_biguint!(1000));
-
-    setup
-        .blockchain
-        .execute_tx(&setup.owner_address, &setup.contract, &rust_biguint!(0), |sc| {
-            sc.assign_role(managed_address!(&proposer_address), managed_buffer!(ROLE_BUILTIN_LEADER));
-            sc.create_permission(
-                managed_buffer!(b"perm"),
-                managed_biguint!(5),
-                managed_address!(&action_receiver),
-                managed_buffer!(b"myendpoint"),
-                ManagedVec::new(),
-                ManagedVec::new(),
-            );
-            sc.create_policy(
-                managed_buffer!(ROLE_BUILTIN_LEADER),
-                managed_buffer!(b"perm"),
-                PolicyMethod::Quorum,
-                BigUint::from(1u64),
-                10,
-            );
-        })
-        .assert_ok();
-
-    setup
-        .blockchain
-        .execute_esdt_transfer(
-            &proposer_address,
-            &setup.contract,
-            ENTITY_GOV_TOKEN_ID,
-            0,
-            &rust_biguint!(ENTITY_GOV_TOKEN_SUPPLY),
-            |sc| {
-                let mut actions = Vec::<Action<DebugApi>>::new();
-
-                actions.push(Action::<DebugApi> {
-                    destination: managed_address!(&action_receiver),
-                    endpoint: managed_buffer!(b"myendpoint"),
-                    arguments: ManagedVec::new(),
-                    gas_limit: 5_000_000u64,
-                    value: managed_biguint!(5),
-                    payments: ManagedVec::new(),
-                });
-
-                let actions_hash = sc.calculate_actions_hash(&ManagedVec::from(actions));
-                let actions_permissions = MultiValueManagedVec::from(vec![managed_buffer!(b"perm")]);
-
-                sc.propose_endpoint(
-                    managed_buffer!(b"id"),
-                    managed_buffer!(b"a"),
-                    managed_buffer!(b"b"),
-                    actions_hash,
-                    POLL_DEFAULT_ID,
-                    actions_permissions,
-                );
-            },
-        )
-        .assert_ok();
-
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
-
-    setup
-        .blockchain
-        .execute_tx(&proposer_address, &setup.contract, &rust_biguint!(0), |sc| {
-            let mut actions = Vec::<Action<DebugApi>>::new();
-
-            actions.push(Action::<DebugApi> {
-                destination: managed_address!(&action_receiver),
-                endpoint: managed_buffer!(b"myendpoint"),
-                arguments: ManagedVec::new(),
-                gas_limit: 5_000_000u64,
-                value: managed_biguint!(5),
-                payments: ManagedVec::new(),
-            });
-
-            sc.execute_endpoint(1, MultiValueManagedVec::from(actions));
-        })
-        .assert_ok();
-
-    setup.blockchain.check_egld_balance(&action_receiver, &rust_biguint!(5));
-}
-
-#[test]
-fn it_fails_if_actions_to_execute_are_incongruent_to_actions_proposed() {
-    let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
 
@@ -426,7 +460,7 @@ fn it_fails_if_actions_to_execute_are_incongruent_to_actions_proposed() {
         )
         .assert_ok();
 
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
 
     setup
         .blockchain
@@ -450,7 +484,6 @@ fn it_fails_if_actions_to_execute_are_incongruent_to_actions_proposed() {
 #[test]
 fn it_executes_a_contract_call_action() {
     let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
 
@@ -517,7 +550,7 @@ fn it_executes_a_contract_call_action() {
         )
         .assert_ok();
 
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
 
     setup
         .blockchain
@@ -543,7 +576,6 @@ fn it_executes_a_contract_call_action() {
 #[test]
 fn it_fails_to_spend_esdt_vote_tokens() {
     let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
     let mut proposal_id = 0;
@@ -622,7 +654,7 @@ fn it_fails_to_spend_esdt_vote_tokens() {
         })
         .assert_ok();
 
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
 
     // but it should FAIL because vote tokens should NOT be spendable
     setup
@@ -647,7 +679,6 @@ fn it_fails_to_spend_esdt_vote_tokens() {
 #[test]
 fn it_fails_to_spend_sft_vote_tokens() {
     let mut setup = EntitySetup::new(entity::contract_obj);
-    let voting_period_seconds = VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60;
     let proposer_address = setup.user_address.clone();
     let action_receiver = setup.blockchain.create_user_account(&rust_biguint!(0));
     let mut proposal_id = 0;
@@ -722,7 +753,7 @@ fn it_fails_to_spend_sft_vote_tokens() {
         })
         .assert_ok();
 
-    setup.blockchain.set_block_timestamp(voting_period_seconds + 1);
+    setup.blockchain.set_block_timestamp(VOTING_PERIOD_MINUTES_DEFAULT as u64 * 60 + 1);
 
     // but it should FAIL because vote tokens should NOT be spendable
     setup

--- a/entity/tests/execute_tests.rs
+++ b/entity/tests/execute_tests.rs
@@ -1,11 +1,11 @@
-use multiversx_sc::codec::multi_types::*;
-use multiversx_sc::types::*;
-use multiversx_sc_scenario::*;
 use entity::config::*;
 use entity::governance::errors::*;
 use entity::governance::proposal::*;
 use entity::governance::*;
 use entity::permission::*;
+use multiversx_sc::codec::multi_types::*;
+use multiversx_sc::types::*;
+use multiversx_sc_scenario::*;
 use setup::*;
 
 mod setup;
@@ -179,7 +179,7 @@ fn it_fails_if_attempted_to_execute_again() {
             sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
             // and again
         })
-        .assert_user_error("proposal is not executable");
+        .assert_user_error("no permission for action");
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn it_fails_if_the_proposal_is_still_active() {
             sc.execute_endpoint(proposal_id, MultiValueManagedVec::from(actions));
             // and again
         })
-        .assert_user_error("proposal is not executable");
+        .assert_user_error("no permission for action");
 }
 
 #[test]

--- a/entity/tests/permission_actual_tests.rs
+++ b/entity/tests/permission_actual_tests.rs
@@ -1,11 +1,11 @@
 use std::vec;
 
-use multiversx_sc::types::*;
-use multiversx_sc_scenario::*;
 use entity::config::*;
 use entity::governance::proposal::*;
 use entity::governance::*;
 use entity::permission::*;
+use multiversx_sc::types::*;
+use multiversx_sc_scenario::*;
 use setup::*;
 
 mod setup;
@@ -69,9 +69,10 @@ fn it_matches_a_permission_based_on_value_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -135,9 +136,10 @@ fn it_matches_a_permission_based_on_destination_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -201,9 +203,10 @@ fn it_matches_a_permission_based_on_endpoint_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -267,9 +270,10 @@ fn it_matches_a_permission_based_on_arguments_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -336,9 +340,10 @@ fn it_matches_a_permission_based_on_payments_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -408,9 +413,10 @@ fn it_matches_a_permission_based_on_destination_and_endpoint() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(allowed);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -477,9 +483,10 @@ fn it_matches_a_permission_based_on_destination_and_endpoint_and_one_argument() 
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let actual = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (actual, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
 
-            assert_eq!(1, actual.len());
+            assert!(actual);
+            assert_eq!(1, permissions.len());
         })
         .assert_ok();
 }
@@ -542,9 +549,12 @@ fn it_does_not_match_zero_value_when_permission_value_is_zero() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let _ = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+
+            assert!(!allowed);
+            assert_eq!(0, permissions.len());
         })
-        .assert_user_error("no permission for action");
+        .assert_ok();
 }
 
 #[test]
@@ -607,9 +617,12 @@ fn it_does_not_match_one_of_many_payments_that_exceeds_permission_max_amount() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let _ = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+
+            assert!(!allowed);
+            assert_eq!(0, permissions.len());
         })
-        .assert_user_error("no permission for action");
+        .assert_ok();
 }
 
 #[test]
@@ -672,7 +685,10 @@ fn it_does_not_match_a_payment_when_there_is_no_permission_for_it() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let _ = sc.get_actual_permissions(&proposal, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+
+            assert!(!allowed);
+            assert_eq!(0, permissions.len());
         })
-        .assert_user_error("no permission for action");
+        .assert_ok();
 }

--- a/entity/tests/permission_actual_tests.rs
+++ b/entity/tests/permission_actual_tests.rs
@@ -69,7 +69,7 @@ fn it_matches_a_permission_based_on_value_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -136,7 +136,7 @@ fn it_matches_a_permission_based_on_destination_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -203,7 +203,7 @@ fn it_matches_a_permission_based_on_endpoint_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -270,7 +270,7 @@ fn it_matches_a_permission_based_on_arguments_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -340,7 +340,7 @@ fn it_matches_a_permission_based_on_payments_only() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -413,7 +413,7 @@ fn it_matches_a_permission_based_on_destination_and_endpoint() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(allowed);
             assert_eq!(1, permissions.len());
@@ -483,7 +483,7 @@ fn it_matches_a_permission_based_on_destination_and_endpoint_and_one_argument() 
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (actual, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (actual, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(actual);
             assert_eq!(1, permissions.len());
@@ -549,7 +549,7 @@ fn it_does_not_match_zero_value_when_permission_value_is_zero() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(!allowed);
             assert_eq!(0, permissions.len());
@@ -617,7 +617,7 @@ fn it_does_not_match_one_of_many_payments_that_exceeds_permission_max_amount() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(!allowed);
             assert_eq!(0, permissions.len());
@@ -685,7 +685,7 @@ fn it_does_not_match_a_payment_when_there_is_no_permission_for_it() {
 
             let proposal = sc.proposals(proposal_id).get();
 
-            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions));
+            let (allowed, permissions) = sc.get_user_permissions_for_actions(&proposal.proposer, &ManagedVec::from(actions), true);
 
             assert!(!allowed);
             assert_eq!(0, permissions.len());

--- a/entity/tests/proposal_status_leaderless_tests.rs
+++ b/entity/tests/proposal_status_leaderless_tests.rs
@@ -1,10 +1,10 @@
-use multiversx_sc::codec::multi_types::*;
-use multiversx_sc::types::*;
-use multiversx_sc_scenario::*;
 use entity::config::*;
 use entity::governance::proposal::*;
 use entity::governance::*;
 use entity::permission::*;
+use multiversx_sc::codec::multi_types::*;
+use multiversx_sc::types::*;
+use multiversx_sc_scenario::*;
 use setup::*;
 
 mod setup;

--- a/entity/wasm/src/lib.rs
+++ b/entity/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           55
+// Endpoints:                           56
 // Async Callback:                       1
-// Total number of exported functions:  57
+// Total number of exported functions:  58
 
 #![no_std]
 #![feature(alloc_error_handler, lang_items)]
@@ -62,6 +62,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         voteAgainst
         sign
         execute
+        directExecute
         withdraw
         issueGovToken
         setGovTokenLocalRoles


### PR DESCRIPTION
Currently, actions can only be executed through the typical proposal flow – even if the caller has unilateral permission. Not the best UX.

This PR adds a `directExecute` endpoint that can be called to execute actions directly.

Requirements:
- must allow a leader to perform actions if leaders = 1
- must NOT allow a leader to perform actions if leaders > 1
- must allow caller with unilateral permission (policy of `One`) to perform actions
- must NOT allow other scenarios